### PR TITLE
fix score scripts on windows 10 environment

### DIFF
--- a/model.py
+++ b/model.py
@@ -566,7 +566,7 @@ if not options.test:
         dev_batch_size = math.ceil(len(dev_instances) * 0.01)
         nbatches = (len(dev_instances) + dev_batch_size - 1) // dev_batch_size
         bar = utils.Progbar(target=nbatches)
-        with open("{}/devout-epoch-{:02d}.txt".format(root_dir, epoch + 1), 'w') as dev_writer:
+        with open("{}/devout-epoch-{:02d}.txt".format(root_dir, epoch + 1), 'w', encoding='utf-8') as dev_writer:
             for batch_id, batch in enumerate(utils.minibatches(dev_instances, dev_batch_size)):
                 for idx, instance in enumerate(batch):
                     sentence = instance.sentence
@@ -644,7 +644,7 @@ prf_dataset = {}
 test_batch_size = math.ceil(len(test_instances) * 0.01)
 nbatches = (len(test_instances) + test_batch_size - 1) // test_batch_size
 bar = utils.Progbar(target=nbatches)
-with open("{}/testout.txt".format(root_dir), 'w') as raw_writer:
+with open("{}/testout.txt".format(root_dir), 'w', encoding='utf-8') as raw_writer:
     for batch_id, batch in enumerate(utils.minibatches(test_instances, test_batch_size)):
         for idx, instance in enumerate(batch):
             if len(instance.sentence) == 0: continue

--- a/official_scorer.py
+++ b/official_scorer.py
@@ -26,14 +26,14 @@ root = tmpdir.name
 datasets = {}
 if options.joint:
     print('Spliting joint test out file into seperate files w.r.t dataset name...')
-    with open(options.test_out) as src:
+    with open(options.test_out, encoding='utf-8') as src:
         for line in src:
             sentence = line.split(' ')
             dataset_name = sentence[0][1:-1]
             dataset_path = '{}/{}.txt'.format(root, dataset_name)
             if dataset_name not in datasets:
                 datasets[dataset_name] = ('data/{}/raw/test.txt'.format(dataset_name), dataset_path)
-            with open(dataset_path, 'a') as des:
+            with open(dataset_path, 'a', encoding='utf-8') as des:
                 des.write(' '.join(sentence[1:-1]))
                 des.write('\n')
 else:
@@ -56,18 +56,18 @@ for dataset_name, (gold_file, test_out) in datasets.items():
     print(dataset_name)
     dic_path = '{}/{}-dic.txt'.format(root, dataset_name)
     dic = set()
-    with open(gold_file) as src:
+    with open(gold_file, encoding='utf-8') as src:
         for line in src:
             sentence = line.split(' ')
             dic.update(sentence)
-    with open(dic_path, 'w') as des:
+    with open(dic_path, 'w', encoding='utf-8') as des:
         for word in dic:
             des.write(word)
             des.write('\n')
 
     cmd = './script/score {} {} {} > tmp'.format(dic_path, gold_file, test_out)
     os.system(cmd)
-    cmd = 'grep \'F MEASURE\' tmp '
+    cmd = 'grep -C 2 \'F MEASURE\' tmp '
     os.system(cmd)
     cmd = 'rm tmp'
     os.system(cmd)

--- a/statistics.py
+++ b/statistics.py
@@ -23,7 +23,7 @@ def count(file):
     size_chars = 0
     dict_word = Counter()
     dict_char = Counter()
-    with open(file) as src:
+    with open(file, encoding='utf-8') as src:
         for line in src:
             size_sentences += 1
             sentence = line.split()

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding:utf-8 -*-
 import codecs
 import errno
 import os
@@ -504,8 +504,8 @@ def evaluate_file(file_name, t2i):
 
 
 def append_tags(src, des, part):
-    with open('data/{}/raw/{}.txt'.format(src, part)) as input, open('data/{}/raw/{}.txt'.format(des, part),
-                                                                     'a') as output:
+    with open('data/{}/raw/{}.txt'.format(src, part), encoding='utf-8') as input, open('data/{}/raw/{}.txt'.format(des, part),
+                                                                     'a', encoding='utf-8') as output:
         for line in input:
             line = line.strip()
             if len(line) > 0:


### PR DESCRIPTION
The official_scorer script has to be run under (windows 10+cygwin) because it replies on 'grep' and 'rm'.